### PR TITLE
install nvim-qt.app, link new location for nvim-qt binary

### DIFF
--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -14,7 +14,8 @@ class NeovimQt < Formula
       ohai "Building Neovim-Qt"
       system "cmake", ".."
       system "make"
-      bin.install "bin/nvim-qt"
+      prefix.install "bin/nvim-qt.app"
+      bin.install_symlink prefix/"nvim-qt.app/Contents/MacOS/nvim-qt"
     end
   end
 end


### PR DESCRIPTION
neovim-qt now creates a Mac app - allow installing it to /Applications as well as keeping the nvim-qt binary for the command line.
Fixes #2.
